### PR TITLE
US-STU-04: Claim Ticket on Event Detail (frontend)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -2,9 +2,71 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import ClaimTicketButton from './components/ClaimTicketButton';
+import { claimTicket, type ClaimSuccess, ClaimTicketError } from "./api/claimTicket";
+import TicketConfirmationModal from "./components/TicketConfirmationModal";
+
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [ticket, setTicket] = useState<ClaimSuccess | null>(null);
+
+  // 1) Define your demo values FIRST
+  const userRole = "student";   // try "guest"
+  const capacity = 100;
+  const claimed = 99;           // set to 100 to see "Sold out"
+  const hasClaimed = false;     // set true to see "Already claimed"
+  //const eventId = "e_demo";     // try "e_demo_sold", "e_demo_dup", "e_demo_unauth"
+
+  const isEligible = userRole === "student";
+  const soldOut = claimed >= capacity;
+
+  // 2) THEN make UI state that uses them
+  const [hasClaimedUI, setHasClaimedUI] = useState(hasClaimed);
+  const [soldOutUI, setSoldOutUI] = useState(soldOut);
+
+async function handleClaimClick() {
+  setMessage("");
+  setTicket(null);
+  setLoading(true);
+  try {
+    const data = await claimTicket(eventId);
+    setTicket(data);
+    setHasClaimedUI(true);                 // ⬅️ after success, disable button
+    setMessage("Ticket claimed!");
+  } catch (err) {
+    if (err instanceof ClaimTicketError) {
+      if (err.reason === "sold_out") {
+        setSoldOutUI(true);                // ⬅️ disable as Sold out
+        setMessage("Sold out ❌");
+      } else if (err.reason === "already_claimed") {
+        setHasClaimedUI(true);             // ⬅️ disable as Already claimed
+        setMessage("You already claimed a ticket ❌");
+      } else if (err.reason === "unauthorized") {
+        setMessage("You must be signed in ❌"); // keep enabled so they can try after sign-in
+      }
+    } else {
+      setMessage("Something went wrong ❌");
+    }
+  } finally {
+    setLoading(false);
+  }
+}
+
+type Variant = "success" | "sold" | "dup" | "unauth";
+
+const [variant, setVariant] = useState<Variant>("success");
+
+const eventIdMap = {
+  success: "e_demo",
+  sold: "e_demo_sold",
+  dup: "e_demo_dup",
+  unauth: "e_demo_unauth",
+} as const;
+
+const eventId = eventIdMap[variant]; // <-- use this in handleClaimClick
 
   return (
     <>
@@ -17,6 +79,38 @@ function App() {
         </a>
       </div>
       <h1>Vite + React</h1>
+      <h2>Claim Ticket demo</h2>
+      <ClaimTicketButton
+        isEligible={isEligible}
+        hasClaimed={hasClaimedUI}   // ⬅️ use UI state
+        soldOut={soldOutUI}         // ⬅️ use UI state
+        loading={loading}
+        onClick={handleClaimClick}
+      />
+
+      
+      {loading && <p style={{ marginTop: 8 }}>⏳ Talking to backend…</p>}
+      {!loading && message && <p role="alert" style={{ marginTop: 8 }}>{message}</p>}
+
+      <TicketConfirmationModal
+        open={!!ticket}
+        data={ticket}
+        onClose={() => setTicket(null)}
+      />
+
+
+      {ticket && (
+        <div style={{ marginTop: 12, padding: 12, border: "1px solid #ddd", borderRadius: 12 }}>
+          <strong>Ticket claimed!</strong>
+          <div>Ticket ID: {ticket.ticketId}</div>
+          <div>Event ID: {ticket.eventId}</div>
+          <div>Seat: {ticket.seat ?? "General Admission"}</div>
+          <div>Claimed at: {new Date(ticket.claimedAt).toLocaleString()}</div>
+          <a href="/me/tickets" style={{ display: "inline-block", marginTop: 8 }}>View my tickets</a>
+      </div>
+    )}
+      
+      <hr />
       <div className="card">
         <button onClick={() => setCount((count) => count + 1)}>
           count is {count}

--- a/src/client/src/api/claimTicket.ts
+++ b/src/client/src/api/claimTicket.ts
@@ -1,0 +1,41 @@
+export type ClaimSuccess = {
+  ticketId: string;
+  eventId: string;
+  claimedAt: string;
+  seat?: string;
+};
+
+export type ClaimErrorReason = "sold_out" | "already_claimed" | "unauthorized";
+
+export class ClaimTicketError extends Error {
+  reason: ClaimErrorReason;
+  constructor(reason: ClaimErrorReason, message?: string) {
+    super(message || reason);
+    this.name = "ClaimTicketError";
+    this.reason = reason;
+  }
+}
+
+export async function claimTicket(eventId: string): Promise<ClaimSuccess> {
+  // simulate network delay so you see loading
+  await new Promise((r) => setTimeout(r, 600));
+
+  // 👇 Trigger different errors by eventId suffix (easy to test)
+  if (eventId.endsWith("_sold")) {
+    throw new ClaimTicketError("sold_out", "Sorry, this event is sold out.");
+  }
+  if (eventId.endsWith("_dup")) {
+    throw new ClaimTicketError("already_claimed", "You already claimed a ticket.");
+  }
+  if (eventId.endsWith("_unauth")) {
+    throw new ClaimTicketError("unauthorized", "You must be signed in.");
+  }
+
+  // success
+  return {
+    ticketId: "t_" + Math.random().toString(36).slice(2, 8),
+    eventId,
+    claimedAt: new Date().toISOString(),
+    seat: "GA",
+  };
+}

--- a/src/client/src/components/ClaimTicketButton.tsx
+++ b/src/client/src/components/ClaimTicketButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+type Props = {
+    isEligible: boolean;    // true if user can claim the ticket
+    hasClaimed: boolean;    // true if user has already claimed the ticket
+    soldOut: boolean;       // true if tickets are sold out
+    loading?: boolean;
+    onClick: () => void;    // action when clicked
+}; 
+
+export default function ClaimTicketButton({
+    isEligible,
+    hasClaimed,
+    soldOut,
+    loading = false,
+    onClick,
+}: Props) {
+    if (!isEligible) return null;
+
+    const disabled = soldOut || hasClaimed || loading;
+    const label = loading
+        ? "Claiming…"                                       // ✅ show while busy
+        : soldOut
+        ? "Sold out"
+        : hasClaimed
+        ? "Already claimed"
+        : "Claim Ticket";
+
+    return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-disabled={disabled}
+      aria-busy={loading}
+      onClick={disabled ? undefined : onClick}
+      style={{
+        padding: "0.6rem 1rem",
+        borderRadius: 12,
+        background: disabled ? "#aaa" : "#671a55ff",
+        color: "white",
+        border: "none",
+        cursor: disabled ? "not-allowed" : "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/client/src/components/TicketConfirmationModal.tsx
+++ b/src/client/src/components/TicketConfirmationModal.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef } from "react";
+import type { ClaimSuccess } from "../api/claimTicket";
+
+type Props = {
+  open: boolean;
+  data: ClaimSuccess | null;
+  onClose: () => void;
+};
+
+export default function TicketConfirmationModal({ open, data, onClose }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape and move focus into the dialog when it opens
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+
+    const prev = document.activeElement as HTMLElement | null;
+    panelRef.current?.focus();
+
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      prev?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!open || !data) return null;
+
+  return (
+    // Overlay
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ticket-confirm-title"
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        zIndex: 1000,
+      }}
+    >
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "100%",
+          maxWidth: 480,
+          background: "white",
+          color: "#111",
+          borderRadius: 16,
+          padding: 20,
+          boxShadow: "0 10px 30px rgba(0,0,0,0.2)",
+        }}
+      >
+        <h2 id="ticket-confirm-title" style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>
+          Ticket claimed!
+        </h2>
+        <p style={{ marginTop: 6, color: "#555" }}>
+          You successfully claimed your ticket for this event.
+        </p>
+
+        <div style={{ marginTop: 12, lineHeight: 1.6 }}>
+          <div><strong>Ticket ID:</strong> {data.ticketId}</div>
+          <div><strong>Event ID:</strong> {data.eventId}</div>
+          <div><strong>Seat:</strong> {data.seat ?? "General Admission"}</div>
+          <div><strong>Claimed at:</strong> {new Date(data.claimedAt).toLocaleString()}</div>
+        </div>
+
+        <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+          <a href="/me/tickets" style={{ padding: "8px 12px", borderRadius: 12, border: "1px solid #ddd", textDecoration: "none" }}>
+            View my tickets
+          </a>
+          <button
+            onClick={onClose}
+            style={{ marginLeft: "auto", padding: "8px 12px", borderRadius: 12, background: "#111", color: "white", border: "none" }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**User Story:** US-STU-04 (Claim Ticket)

### What’s included
- Claim Ticket button (hidden for ineligible users)
- Disabled states: Sold out / Already claimed / Loading
- Success: accessible confirmation modal with ticket info
- Error states: sold out, already claimed, unauthorized (alert)
- Responsive + a11y (role="dialog", role="alert", Escape to close)
- Scenario switcher for testing (success/sold/dup/unauth)

### How to test
**_Basically at line 60 in App.tsx, either put "success" | "sold" | "dup" | "unauth";_**
1) Run frontend (:5173).
2) Use the "Scenario" dropdown to switch outcomes:
   - Success → modal shows ticket details
   - Sold out / Already claimed / Unauthorized → clear messages
3) Button hides when `isEligible` is false; disables appropriately.

### Acceptance Criteria
- [x] Button only visible for eligible users
- [x] Success flow shows confirmation with ticket info
- [x] Error states clearly displayed
- [x] Responsive and accessible UI

Linked to: US-STU-04
