### PR TITLE
US-STU-03: Create saves table with composite PK & FKs; update schema …

### DIFF
--- a/docs/db/schema.md
+++ b/docs/db/schema.md
@@ -1,0 +1,13 @@
+### saves
+
+Stores a student’s “saved” events (personal list).
+
+| column     | type        | constraints                                  |
+|------------|-------------|-----------------------------------------------|
+| user_id    | integer     | FK → users.id, part of PK, ON DELETE CASCADE |
+| event_id   | integer     | FK → events.id, part of PK, ON DELETE CASCADE|
+| created_at | timestamptz | DEFAULT now()                                 |
+
+**Primary Key:** (user_id, event_id)  
+**Indexes:** ix_saves_user(user_id), ix_saves_event(event_id)  
+**Notes:** Composite PK prevents duplicate saves for the same user/event.

--- a/src/server/db/migrations/20251006_create_saves.sql
+++ b/src/server/db/migrations/20251006_create_saves.sql
@@ -1,0 +1,13 @@
+-- US-STU-03: Create saves table (user "saves" an event to personal list)
+-- Idempotent: safe to run multiple times.
+
+CREATE TABLE IF NOT EXISTS saves (
+  user_id  INTEGER NOT NULL REFERENCES users(id)  ON DELETE CASCADE,
+  event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT pk_saves PRIMARY KEY (user_id, event_id)
+);
+
+-- Helpful indexes (the PK already indexes both columns together; these help filtered lookups)
+CREATE INDEX IF NOT EXISTS ix_saves_user  ON saves(user_id);
+CREATE INDEX IF NOT EXISTS ix_saves_event ON saves(event_id);

--- a/src/server/db/migrations/20251006_drop_saves.sql
+++ b/src/server/db/migrations/20251006_drop_saves.sql
@@ -1,0 +1,2 @@
+-- Rollback for US-STU-03
+DROP TABLE IF EXISTS saves;


### PR DESCRIPTION
Implements the saves table for user event lists.

- Columns: user_id, event_id, created_at
- Composite PK (user_id, event_id) prevents duplicates
- FKs: user_id → users.id, event_id → events.id (ON DELETE CASCADE)
- Added migration + rollback scripts
- Updated /docs/db/schema.md

✅ Migration tested
✅ FKs verified
✅ Duplicate inserts blocked

Linked to parent story: US-STU-03
