### PR TITLE
Task-STU-02-DB: Add DB query for remaining capacity

### DIFF
--- a/docs/db/queries.md
+++ b/docs/db/queries.md
@@ -1,0 +1,21 @@
+## STU-02-DB — Remaining Capacity Query
+
+**Purpose:** Compute how many seats remain for an event.
+
+**Formula:** `remaining = capacity - tickets_claimed`
+
+**SQL (single event):**
+
+```sql
+SELECT
+  e.id AS event_id,
+  e.capacity,
+  COALESCE(COUNT(t.id), 0) AS tickets_claimed,
+  GREATEST(0, e.capacity - COALESCE(COUNT(t.id), 0)) AS remaining
+FROM events e
+LEFT JOIN tickets t
+  ON t.event_id = e.id
+  AND t.status = 'claimed'  -- count only claimed tickets
+WHERE e.id = $1              -- replace with a specific event id
+GROUP BY e.id, e.capacity;
+```

--- a/src/server/db/migrations/remaining_capacity_query.sql
+++ b/src/server/db/migrations/remaining_capacity_query.sql
@@ -1,0 +1,23 @@
+-- 002_remaining_capacity_query.sql
+-- Purpose: Compute remaining capacity for events.
+-- Task: STU-02-DB (Add DB query for remaining capacity)
+-- ------------------------------------------------------
+-- This query calculates remaining seats for any given event:
+-- remaining = capacity - tickets_claimed
+-- where tickets_claimed = COUNT(*) of claimed tickets per event.
+-- Index on (event_id) in tickets ensures performance.
+
+-- Example query:
+SELECT
+  e.id AS event_id,
+  e.capacity,
+  COALESCE(COUNT(t.id), 0) AS tickets_claimed,
+  GREATEST(0, e.capacity - COALESCE(COUNT(t.id), 0)) AS remaining
+FROM events e
+LEFT JOIN tickets t
+  ON t.event_id = e.id
+  AND t.status = 'claimed'
+WHERE e.id = $1
+GROUP BY e.id, e.capacity;
+
+-- No schema changes required (index already present: ux_tickets_event_user).


### PR DESCRIPTION
Implements Task STU-02-DB 

- Adds SQL to compute remaining seats:
  remaining = capacity - tickets_claimed (claimed = tickets with status = 'claimed')
- Verified performance via EXPLAIN ANALYZE (uses existing index ux_tickets_event_user on (event_id, user_id))
- Edge case confirmed: capacity = 0 -> remaining = 0
- Query documented in /docs/db/queries.md

Closes #35