### PR TITLE
ADM-01-FE: Admin UI for Approving/Rejecting Organizer Accounts

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1949,6 +1950,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2921,6 +2931,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
+      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
+      "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3023,6 +3071,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -3,33 +3,55 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 
+import { Routes, Route, Link } from 'react-router-dom'
+import OrganizerApprovalsPage from './pages/admin/OrganizerApprovalsPage'
+
+
 function App() {
   const [count, setCount] = useState(0)
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  <div>
+    {/* simple nav while developing */}
+    <nav style={{ padding: '8px' }}>
+      <Link to="/">Home</Link>{" | "}
+      <Link to="/admin/organizers?dev=1">Admin » Organizers</Link>
+    </nav>
+
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <>
+            <div>
+              <a href="https://vite.dev" target="_blank">
+                <img src={viteLogo} className="logo" alt="Vite logo" />
+              </a>
+              <a href="https://react.dev" target="_blank">
+                <img src={reactLogo} className="logo react" alt="React logo" />
+              </a>
+            </div>
+            <h1>Vite + React</h1>
+            <div className="card">
+              <button onClick={() => setCount((count) => count + 1)}>
+                count is {count}
+              </button>
+              <p>
+                Edit <code>src/App.tsx</code> and save to test HMR
+              </p>
+            </div>
+            <p className="read-the-docs">
+              Click on the Vite and React logos to learn more
+            </p>
+          </>
+        }
+      />
+      <Route path="/admin/organizers" element={<OrganizerApprovalsPage />} />
+      <Route path="*" element={<div style={{ padding: 16 }}>Not Found</div>} />
+    </Routes>
+  </div>
+)
+
 }
 
 export default App

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'   // ⬅️ add this
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/client/src/pages/admin/OrganizerApprovalsPage.tsx
+++ b/src/client/src/pages/admin/OrganizerApprovalsPage.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+
+
+
+type Pending = {
+  id: number;
+  name: string;
+  email: string;
+  organization: string;
+  submittedAt: string;
+};
+
+export default function OrganizerApprovalsPage() {
+  const [search] = useSearchParams();
+  const isAdmin = search.get("dev") === "1"; // DEV ONLY: use ?dev=1 to view      
+  const [pending, setPending] = useState<Pending[]>([
+    {
+      id: 101,
+      name: "Avery Chen",
+      email: "avery@club.ca",
+      organization: "Robotics Club",
+      submittedAt: new Date().toISOString(),
+    },
+    {
+      id: 102,
+      name: "Jordan Patel",
+      email: "jordan@music.ca",
+      organization: "Music Society",
+      submittedAt: new Date().toISOString(),
+    },
+  ]);
+
+  if (!isAdmin) {
+  return (
+    <div style={{ padding: 24, color: "#fff", textAlign: "center" }}>
+      <h1 style={{ fontSize: 24, marginBottom: 12 }}>Organizer Approvals</h1>
+      <div style={{ margin: "16px auto", maxWidth: 520, padding: 16, borderRadius: 10, background: "#2a1c1c", border: "1px solid #a43b3b", color: "#ffb5b5" }}>
+        <strong>Access denied</strong>
+        <div style={{ fontSize: 14, opacity: 0.9, marginTop: 6 }}>
+          You must be an administrator to view this page.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+  const [toast, setToast] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  // mock API (replace with real POST later)
+  async function postDecision(id: number, action: "approve" | "reject") {
+    await new Promise((r) => setTimeout(r, 500)); // pretend network
+    return { ok: true };
+  }
+
+  async function onDecision(row: Pending, action: "approve" | "reject") {
+    setBusyId(row.id);
+    // optimistic remove
+    setPending((prev) => prev.filter((r) => r.id !== row.id));
+    try {
+      const res = await postDecision(row.id, action);
+      if (!res.ok) throw new Error("Request failed");
+      setToast({ type: "success", msg: `${action === "approve" ? "Approved" : "Rejected"} ${row.name}` });
+    } catch (e) {
+      // revert on error
+      setPending((prev) => [row, ...prev]);
+      setToast({ type: "error", msg: (e as Error).message || "Action failed" });
+    } finally {
+      setBusyId(null);
+      // auto-hide toast
+      setTimeout(() => setToast(null), 2500);
+    }
+  }
+
+  return (
+    <div style={{ padding: 24, color: "#fff" }}>
+      <h1 style={{ fontSize: 24, marginBottom: 12, textAlign: "center" }}>Organizer Approvals</h1>
+
+      {/* Toast */}
+      {toast && (
+        <div
+          role="status"
+          style={{
+            margin: "0 auto 12px",
+            maxWidth: 520,
+            padding: "10px 12px",
+            borderRadius: 10,
+            background: toast.type === "success" ? "#103d25" : "#3d1010",
+            border: `1px solid ${toast.type === "success" ? "#1f8a4c" : "#a43b3b"}`,
+            color: toast.type === "success" ? "#b5ffd4" : "#ffb5b5",
+            textAlign: "center",
+          }}
+        >
+          {toast.msg}
+        </div>
+      )}
+
+      <div
+        style={{
+          background: "#141414",
+          borderRadius: 12,
+          padding: 16,
+          maxWidth: 520,
+          margin: "0 auto",
+          boxShadow: "0 4px 16px rgba(0,0,0,0.3)",
+        }}
+      >
+        <p style={{ marginBottom: 8, color: "#bbb", textAlign: "center" }}>
+          Pending Organizer Requests ({pending.length})
+        </p>
+
+        {pending.length === 0 ? (
+          <div style={{ color: "#9aa", textAlign: "center", padding: 16 }}>No pending organizer requests.</div>
+        ) : (
+          pending.map((org) => (
+            <div
+              key={org.id}
+              style={{
+                background: "#1f1f1f",
+                marginBottom: 8,
+                padding: 12,
+                borderRadius: 8,
+                border: "1px solid #2b2b2b",
+              }}
+            >
+              <strong>{org.name}</strong> — {org.email} · {org.organization}
+              <br />
+              <small>Submitted {new Date(org.submittedAt).toLocaleString()}</small>
+              <div style={{ marginTop: 8 }}>
+                <button
+                  onClick={() => onDecision(org, "approve")}
+                  disabled={busyId === org.id}
+                  style={{ marginRight: 8, padding: "6px 12px", borderRadius: 8 }}
+                >
+                  {busyId === org.id ? "Working…" : "Approve"}
+                </button>
+                <button
+                  onClick={() => onDecision(org, "reject")}
+                  disabled={busyId === org.id}
+                  style={{ padding: "6px 12px", borderRadius: 8 }}
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      
+
+      <p style={{ marginTop: 8, textAlign: "center", color: "#778" }}>
+        (UI mocked — we’ll hook real endpoints next)
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Parent Story
US-ADM-01 (Approve Organizer Accounts)

## Summary
Admin Organizer Approvals UI with mock data. Shows pending requests, Approve/Reject actions with optimistic update, toasts, and admin gate (dev bypass via ?dev=1).

## Acceptance Criteria
- List view of pending organizers (mock data)
- Approve/Reject updates status (optimistic remove)
- Confirmation/error messages  (toast)
- Only admins can access (gate; dev bypass ?dev=1)
- Real-time after action  (instant UI update)

## Files
- client/src/pages/admin/OrganizerApprovalsPage.tsx
- client/src/App.tsx
- client/src/main.tsx

## TODO (future BE integration)
- GET /api/admin/organizers?status=pending
- POST /api/admin/organizers/:id/approve
- POST /api/admin/organizers/:id/reject
- Replace ?dev=1 with real /api/auth/me role check

## Linked
US-ADM-01
