### PR TITLE
ADM-01-BE: Implement approval/rejection endpoints

### DIFF
--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -1,17 +1,26 @@
+// src/server/db/index.js
 const { Pool } = require("pg");
-require("dotenv").config();
+const path = require("path");
+
+// ✅ Load the root .env (two levels up from this file)
+require("dotenv").config({ path: path.resolve(__dirname, "../../.env") });
 
 const pool = new Pool({
   user: process.env.DB_USER,
-  host: process.env.DB_HOST,
-  database: process.env.DB_NAME,
-  password: process.env.DB_PASS,
+  host: process.env.DB_HOST || "localhost",
+  database: process.env.DB_NAME || "campus_events",
+  password: process.env.DB_PASS || undefined,
   port: Number(process.env.DB_PORT || 5432),
   max: 10,
   idleTimeoutMillis: 30000,
 });
 
-pool.on("connect", () => console.log("✅ Connected to PostgreSQL"));
+pool.on("connect", () => {
+  console.log(
+    "✅ Connected to PostgreSQL",
+    `(db=${process.env.DB_NAME || "campus_events"}, host=${process.env.DB_HOST || "localhost"})`
+  );
+});
 
 module.exports = {
   query: (text, params) => pool.query(text, params),

--- a/src/server/db/migrations/20251010_adm01_organizer_status_and_moderation_log.sql
+++ b/src/server/db/migrations/20251010_adm01_organizer_status_and_moderation_log.sql
@@ -1,0 +1,25 @@
+-- ADM-01-BE migration
+
+-- 1) Add status + audit columns to organizers
+ALTER TABLE organizers
+  ADD COLUMN IF NOT EXISTS organizer_status TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS approved_by INTEGER REFERENCES users(id),
+  ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rejected_by INTEGER REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_organizers_status ON organizers(organizer_status);
+
+-- 2) Moderation log table for audit trail
+CREATE TABLE IF NOT EXISTS moderation_log (
+  id BIGSERIAL PRIMARY KEY,
+  admin_id INTEGER NOT NULL REFERENCES users(id),
+  target_type TEXT NOT NULL,        -- e.g. 'organizer'
+  target_id INTEGER NOT NULL,
+  action TEXT NOT NULL,             -- 'approve_organizer' | 'reject_organizer'
+  details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_log_target ON moderation_log(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_moderation_log_admin ON moderation_log(admin_id);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,6 +6,9 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+const adminOrganizersRouter = require('./routes/admin.organizers');
+app.use('/api/admin', adminOrganizersRouter);
+
 const PORT = process.env.PORT || 3000;
 
 app.get('/health', (_req, res) => {
@@ -15,3 +18,10 @@ app.get('/health', (_req, res) => {
 app.listen(PORT, () => {
   console.log(`Server listening on http://localhost:${PORT}`);
 });
+
+// Force a DB connection on startup to see errors immediately
+const db = require('./db');
+db.query('SELECT 1')
+  .then(() => console.log('✅ DB ping OK'))
+  .catch((err) => console.error('❌ DB ping FAILED', err));
+

--- a/src/server/middleware/requireAdmin.js
+++ b/src/server/middleware/requireAdmin.js
@@ -1,0 +1,24 @@
+const db = require('../db');
+
+module.exports = async function requireAdmin(req, res, next) {
+  try {
+    const userId = req.headers['x-user-id']; // FE/backoffice should send this
+    if (!userId) return res.status(401).json({ error: 'Unauthorized: missing user' });
+
+    // Look up user role
+    const { rows } = await db.query(
+      'SELECT id, role FROM users WHERE id = $1',
+      [userId]
+    );
+    const me = rows[0];
+    if (!me) return res.status(401).json({ error: 'Unauthorized: user not found' });
+    if (me.role !== 'admin') return res.status(403).json({ error: 'Forbidden: admin only' });
+
+    // attach for later use
+    req.admin = { id: me.id };
+    next();
+  } catch (err) {
+    console.error('requireAdmin error', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+};

--- a/src/server/routes/admin.organizers.js
+++ b/src/server/routes/admin.organizers.js
@@ -1,0 +1,100 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+const requireAdmin = require('../middleware/requireAdmin');
+
+// All routes here require admin
+router.use(requireAdmin);
+
+// internal helper: update status + log (inside a transaction)
+async function updateOrganizerStatus(client, { organizerId, action, adminId }) {
+  if (!['approve', 'reject'].includes(action)) {
+    const e = new Error('Invalid action'); e.status = 400; throw e;
+  }
+  const nextStatus = action === 'approve' ? 'approved' : 'rejected';
+  const stampCol = action === 'approve' ? 'approved_at' : 'rejected_at';
+  const byCol    = action === 'approve' ? 'approved_by' : 'rejected_by';
+
+  // Only allow transition from pending
+  const upd = await client.query(
+    `
+    UPDATE organizations
+       SET organizer_status = $2,
+           ${stampCol} = now(),
+           ${byCol} = $3
+     WHERE id = $1
+       AND organizer_status = 'pending'
+     RETURNING id
+    `,
+    [organizerId, nextStatus, adminId]
+  );
+
+  if (upd.rowCount === 0) {
+    // Either not found or not pending
+    const check = await client.query(
+      'SELECT id, organizer_status FROM organizations WHERE id = $1',
+      [organizerId]
+    );
+    if (check.rowCount === 0) {
+      const e = new Error('Organizer not found'); e.status = 404; throw e;
+    } else {
+      const e = new Error(`Organizer is not pending (status=${check.rows[0].organizer_status})`);
+      e.status = 409; throw e;
+    }
+  }
+
+  // moderation log
+  await client.query(
+    `INSERT INTO moderation_log (admin_id, target_type, target_id, action, details)
+     VALUES ($1, 'organizer', $2, $3, '{}'::jsonb)`,
+    [adminId, organizerId, `${action}_organizer`]
+  );
+
+  return { id: upd.rows[0].id, status: nextStatus };
+}
+
+// POST /admin/organizers/:id/approve
+router.post('/organizers/:id/approve', async (req, res) => {
+  const organizerId = Number(req.params.id);
+  if (!Number.isFinite(organizerId)) return res.status(400).json({ error: 'Invalid id' });
+
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await updateOrganizerStatus(client, {
+      organizerId, action: 'approve', adminId: req.admin.id
+    });
+    await client.query('COMMIT');
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('approve error', err);
+    res.status(err.status || 500).json({ error: err.message || 'Internal error' });
+  } finally {
+    client.release();
+  }
+});
+
+// POST /admin/organizers/:id/reject
+router.post('/organizers/:id/reject', async (req, res) => {
+  const organizerId = Number(req.params.id);
+  if (!Number.isFinite(organizerId)) return res.status(400).json({ error: 'Invalid id' });
+
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await updateOrganizerStatus(client, {
+      organizerId, action: 'reject', adminId: req.admin.id
+    });
+    await client.query('COMMIT');
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('reject error', err);
+    res.status(err.status || 500).json({ error: err.message || 'Internal error' });
+  } finally {
+    client.release();
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Parent: US-ADM-01 (Approve Organizer Accounts)

Adds:
- POST /api/admin/organizers/:id/approve
- POST /api/admin/organizers/:id/reject
- Admin check via requireAdmin (x-user-id)
- Pending-only transition; returns 404/409 when appropriate
- Moderation logging to moderation_log (admin_id, action, timestamp)

Tested:
- curl happy path and error paths locally
- DB updated (organizations.organizer_status), log row created

TODO (separate FE PR): FE uses these endpoints.