### PR TITLE
US-ORG-04: Export Attendee List — query + indexes

### DIFF
--- a/docs/db/queries.md
+++ b/docs/db/queries.md
@@ -19,3 +19,30 @@ LEFT JOIN tickets t
 WHERE e.id = $1              -- replace with a specific event id
 GROUP BY e.id, e.capacity;
 ```
+
+
+## attendees_by_event (US-ORG-04)
+
+**Purpose:** Return attendee details for a given `event_id` for organizer export.
+
+**Parameters**
+- `event_id` (int): event to export.
+
+**Columns**
+- `user_name`, `email`, `ticket_id`, `ticket_status`, `issued_at`, `checked_in_at`
+
+**PostgreSQL**
+```sql
+SELECT
+  u.name AS user_name,
+  u.email,
+  t.id AS ticket_id,
+  t.status AS ticket_status,
+  t.issued_at,
+  t.checked_in_at
+FROM tickets t
+JOIN users u  ON u.id = t.user_id
+JOIN events e ON e.id = t.event_id
+WHERE t.event_id = $1
+ORDER BY u.name, t.id;
+

--- a/src/server/db/migrations/20251029_add_ticket_indexes.sql
+++ b/src/server/db/migrations/20251029_add_ticket_indexes.sql
@@ -1,0 +1,13 @@
+-- Adds helpful indexes for attendee export (US-ORG-04)
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tickets_event_id 
+  ON tickets(event_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tickets_user_id 
+  ON tickets(user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tickets_event_user_cover
+  ON tickets(event_id, user_id)
+  INCLUDE (status, issued_at, checked_in_at);
+
+

--- a/src/server/db/queries/attendees_by_event.sql
+++ b/src/server/db/queries/attendees_by_event.sql
@@ -1,0 +1,15 @@
+-- Returns attendee details for a single event.
+-- Parameter: $1 = event_id (integer)
+
+SELECT
+  u.name        AS user_name,
+  u.email       AS email,
+  t.id          AS ticket_id,
+  t.status      AS ticket_status,
+  t.issued_at   AS issued_at,
+  t.checked_in_at AS checked_in_at
+FROM tickets AS t
+JOIN users   AS u ON u.id = t.user_id
+JOIN events  AS e ON e.id = t.event_id
+WHERE t.event_id = $1
+ORDER BY u.name, t.id;


### PR DESCRIPTION
Implements attendee export query for a given event_id.

Scope
- SQL query: attendees_by_event.sql
- Indexes: 20251029_add_ticket_indexes.sql
- Docs: docs/db/queries.md

How to test
1) Ensure DB is running and env loaded.
2) Run the query for any event (example uses id=2):
   SELECT
     u.name AS user_name,
     u.email,
     t.id AS ticket_id,
     t.status AS ticket_status,
     t.issued_at,
     t.checked_in_at
   FROM tickets t
   JOIN users u ON u.id = t.user_id
   JOIN events e ON e.id = t.event_id
   WHERE t.event_id = 2
   ORDER BY u.name, t.id;

Performance
- Indexes added: tickets(event_id), tickets(user_id)
- (Optional) Composite: tickets(event_id, user_id) INCLUDE (status, issued_at, checked_in_at)

Acceptance Criteria
- Returns correct attendee data for given event_id
- Performance acceptable for large events (1000+ tickets)
- Query documented in /docs/db/queries.md

Linked to: Parent story US-ORG-04
