### PR TITLE
Complete: Task-ORG-06-FE-01: Build Organizer Waitlist Tab (Table + Controls)

### DIFF
--- a/src/client/src/components/WaitlistTable.tsx
+++ b/src/client/src/components/WaitlistTable.tsx
@@ -1,0 +1,96 @@
+// src/components/organizer/WaitlistTable.tsx
+import type { FC } from "react";
+import type { WaitlistEntry } from "../lib/waitlist.api";
+
+interface WaitlistTableProps {
+  items: WaitlistEntry[];
+  loading?: boolean;
+  canManage: boolean;
+  onPromote: (entry: WaitlistEntry) => void;
+  onRemove: (entry: WaitlistEntry) => void;
+}
+
+const formatDateTime = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+};
+
+const WaitlistTable: FC<WaitlistTableProps> = ({
+  items,
+  loading = false,
+  canManage,
+  onPromote,
+  onRemove,
+}) => {
+  if (!items.length) {
+    return (
+      <div className="rounded-md border p-4 text-sm text-slate-500">
+        No one is currently on the waitlist for this event.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="min-w-full text-sm">
+        <thead className="bg-slate-100">
+          <tr>
+            <th className="px-4 py-2 text-left font-semibold">Attendee</th>
+            <th className="px-4 py-2 text-left font-semibold">Joined</th>
+            <th className="px-4 py-2 text-left font-semibold">Status</th>
+            <th className="px-4 py-2 text-left font-semibold">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((entry) => (
+            <tr
+              key={entry.id}
+              className="border-t last:border-b hover:bg-slate-50"
+            >
+              <td className="px-4 py-2">{entry.attendeeName}</td>
+              <td className="px-4 py-2">{formatDateTime(entry.joinedAt)}</td>
+              <td className="px-4 py-2">
+                <span className="rounded-full bg-slate-100 px-2 py-1 text-xs uppercase tracking-wide">
+                  {entry.status}
+                </span>
+              </td>
+              <td className="px-4 py-2">
+                {canManage ? (
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      disabled={
+                        loading ||
+                        entry.status === "PROMOTED" ||
+                        entry.status === "REMOVED"
+                      }
+                      className="rounded-md border px-3 py-1 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => onPromote(entry)}
+                    >
+                      Promote
+                    </button>
+                    <button
+                      type="button"
+                      disabled={loading || entry.status === "REMOVED"}
+                      className="rounded-md border px-3 py-1 text-xs font-medium text-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => onRemove(entry)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ) : (
+                  <span className="text-xs text-slate-400">
+                    View-only (not event owner)
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default WaitlistTable;

--- a/src/client/src/lib/waitlist.api.ts
+++ b/src/client/src/lib/waitlist.api.ts
@@ -1,0 +1,65 @@
+// src/lib/waitlist.api.ts
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:4000";
+
+export type WaitlistStatus = "WAITING" | "PROMOTED" | "REMOVED";
+
+export interface WaitlistEntry {
+  id: string;
+  userId: string;
+  attendeeName: string;
+  joinedAt: string; // ISO string
+  status: WaitlistStatus;
+}
+
+export async function fetchWaitlist(eventId: string, token?: string) {
+  const res = await axios.get<WaitlistEntry[]>(
+    `${BASE_URL}/organizer/events/${eventId}/waitlist`,
+    {
+      headers: token
+        ? {
+            Authorization: `Bearer ${token}`,
+          }
+        : undefined,
+    }
+  );
+  return res.data;
+}
+
+export async function promoteFromWaitlist(
+  eventId: string,
+  entryId: string,
+  token?: string
+) {
+  const res = await axios.post<WaitlistEntry>(
+    `${BASE_URL}/organizer/events/${eventId}/waitlist/${entryId}/promote`,
+    {},
+    {
+      headers: token
+        ? {
+            Authorization: `Bearer ${token}`,
+          }
+        : undefined,
+    }
+  );
+  return res.data;
+}
+
+export async function removeFromWaitlist(
+  eventId: string,
+  entryId: string,
+  token?: string
+) {
+  const res = await axios.delete(
+    `${BASE_URL}/organizer/events/${eventId}/waitlist/${entryId}`,
+    {
+      headers: token
+        ? {
+            Authorization: `Bearer ${token}`,
+          }
+        : undefined,
+    }
+  );
+  return res.data;
+}

--- a/src/client/src/pages/EventDetail.tsx
+++ b/src/client/src/pages/EventDetail.tsx
@@ -5,6 +5,7 @@ import SaveButton from "../components/SaveButton";
 import ClaimTicketButton from "../components/ClaimTicketButton";
 import TicketConfirmationModal from "../components/TicketConfirmationModal";
 import { claimTicket, ClaimTicketError, type ClaimSuccess } from "../api/claimTicket";
+import EventWaitlistTab from "./EventWaitlistTab";
 
 // Match shape coming from backend (adjust names if your API differs)
 interface EventData {
@@ -14,8 +15,8 @@ interface EventData {
   category: string;
   location: string;
   organizer: string;
-  start_time: string;     // ISO
-  end_time: string;       // ISO
+  start_time: string; // ISO
+  end_time: string; // ISO
   capacity: number;
   remaining_seats: number;
   ticket_type: "free" | "paid";
@@ -27,6 +28,7 @@ const DEV_USER_ID = import.meta.env.VITE_DEV_USER_ID || "1"; // dev-only auth
 
 export default function EventDetail() {
   const { id } = useParams<{ id: string }>();
+
   const [event, setEvent] = useState<EventData | null>(null);
   const [loading, setLoading] = useState(true);
   const [errMsg, setErrMsg] = useState<string | null>(null);
@@ -36,9 +38,11 @@ export default function EventDetail() {
   const [hasClaimed, setHasClaimed] = useState(false);
   const [ticket, setTicket] = useState<ClaimSuccess | null>(null);
 
-  const userRole = "student"; // demo
+  // TODO: replace this with real auth/role from context
+  const userRole: string = "student";
   const isStudent = userRole === "student";
-
+  const isOrganizer = userRole === "organizer" || userRole === "admin";
+  
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
@@ -53,39 +57,47 @@ export default function EventDetail() {
             "X-User-Id": DEV_USER_ID, // dev-only bypass
           },
         });
-        if (!res.ok) throw new Error(`Failed to fetch event (HTTP ${res.status})`);
+
+        if (!res.ok) {
+          throw new Error(`Failed to fetch event (HTTP ${res.status})`);
+        }
 
         const data: EventData = await res.json();
 
-        // If you keep unpublished events in DB, guard them from students
-        if (data.is_published === false) {
+        // Guard unpublished events from regular students
+        if (data.is_published === false && !isOrganizer) {
           throw new Error("This event is not published.");
         }
 
-        if (!cancelled) setEvent(data);
-      } catch (e: any) {
-        if (!cancelled) setErrMsg(e.message || "Unable to load event details.");
+        if (!cancelled) {
+          setEvent(data);
+        }
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error ? e.message : "Unable to load event details.";
+        if (!cancelled) {
+          setErrMsg(msg);
+        }
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, isOrganizer]);
 
-  // ...
-async function handleClaim() {
-  if (!id || claimLoading) return;
-  setClaimLoading(true);
-  try {
-    // ✅ pass numeric id to your API helper
-    const result = await claimTicket(Number(id));
-    setTicket(result);
-    setHasClaimed(true);
-  } catch (e) {
-    // unchanged…
+  async function handleClaim() {
+    if (!id || claimLoading) return;
+    setClaimLoading(true);
+    try {
+      const result = await claimTicket(Number(id));
+      setTicket(result);
+      setHasClaimed(true);
+    } catch (e: unknown) {
       if (e instanceof ClaimTicketError) {
         alert(
           e.reason === "sold_out"
@@ -110,8 +122,16 @@ async function handleClaim() {
         <div className="skeleton" style={{ height: 16, width: "90%", marginBottom: 8 }} />
         <div className="skeleton" style={{ height: 180, width: "100%", marginTop: 16 }} />
         <style>{`
-          .skeleton { background: linear-gradient(90deg,#2a2a2a 25%,#3a3a3a 37%,#2a2a2a 63%); background-size: 400% 100%; animation: shimmer 1.2s infinite; border-radius: 10px; }
-          @keyframes shimmer { 0%{background-position: 100% 0} 100%{background-position: 0 0} }
+          .skeleton {
+            background: linear-gradient(90deg,#2a2a2a 25%,#3a3a3a 37%,#2a2a2a 63%);
+            background-size: 400% 100%;
+            animation: shimmer 1.2s infinite;
+            border-radius: 10px;
+          }
+          @keyframes shimmer {
+            0% { background-position: 100% 0 }
+            100% { background-position: 0 0 }
+          }
         `}</style>
       </div>
     );
@@ -119,7 +139,14 @@ async function handleClaim() {
 
   if (errMsg) {
     return (
-      <div style={{ padding: "2rem", maxWidth: 720, margin: "0 auto", color: "#ffb5b5" }}>
+      <div
+        style={{
+          padding: "2rem",
+          maxWidth: 720,
+          margin: "0 auto",
+          color: "#ffb5b5",
+        }}
+      >
         <h2 style={{ margin: 0 }}>Unable to load event</h2>
         <p style={{ marginTop: 6, color: "#ffcccc" }}>{errMsg}</p>
       </div>
@@ -136,29 +163,43 @@ async function handleClaim() {
 
   const soldOut = event.remaining_seats <= 0;
 
-  function downloadIcs(ev: {title:string; start_time:string; end_time?:string; location?:string}) {
+  function downloadIcs(ev: {
+    title: string;
+    start_time: string;
+    end_time?: string;
+    location?: string;
+  }) {
     const lines = [
       "BEGIN:VCALENDAR",
       "VERSION:2.0",
       "PRODID:-//Campus Events//EN",
       "BEGIN:VEVENT",
       `UID:${ev.title}-${ev.start_time}`,
-      `DTSTAMP:${new Date().toISOString().replace(/[-:]/g,"").split(".")[0]}Z`,
-      `DTSTART:${ev.start_time.replace(/[-:]/g,"").split(".")[0]}Z`,
-      ev.end_time ? `DTEND:${ev.end_time.replace(/[-:]/g,"").split(".")[0]}Z` : "",
+      `DTSTAMP:${new Date()
+        .toISOString()
+        .replace(/[-:]/g, "")
+        .split(".")[0]}Z`,
+      `DTSTART:${ev.start_time.replace(/[-:]/g, "").split(".")[0]}Z`,
+      ev.end_time
+        ? `DTEND:${ev.end_time.replace(/[-:]/g, "").split(".")[0]}Z`
+        : "",
       `SUMMARY:${ev.title}`,
       ev.location ? `LOCATION:${ev.location}` : "",
       "END:VEVENT",
       "END:VCALENDAR",
-    ].filter(Boolean).join("\r\n");
-    const blob = new Blob([lines], { type: "text/calendar;charset=utf-8" });
+    ]
+      .filter(Boolean)
+      .join("\r\n");
+
+    const blob = new Blob([lines], {
+      type: "text/calendar;charset=utf-8",
+    });
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
     a.download = `${ev.title}.ics`;
     a.click();
     URL.revokeObjectURL(a.href);
   }
-  
 
   return (
     <div style={{ padding: "2rem", maxWidth: 820, margin: "0 auto" }}>
@@ -187,24 +228,46 @@ async function handleClaim() {
         >
           <Info label="Location" value={event.location} />
           <Info label="Organizer" value={event.organizer} />
-          <Info label="Starts" value={new Date(event.start_time).toLocaleString()} />
-          <Info label="Ends" value={new Date(event.end_time).toLocaleString()} />
+          <Info
+            label="Starts"
+            value={new Date(event.start_time).toLocaleString()}
+          />
+          <Info
+            label="Ends"
+            value={new Date(event.end_time).toLocaleString()}
+          />
           <Info
             label="Capacity"
             value={`${event.capacity - event.remaining_seats}/${event.capacity} filled`}
           />
-          <Info label="Ticket Type" value={event.ticket_type === "free" ? "Free" : "Paid"} />
+          <Info
+            label="Ticket Type"
+            value={event.ticket_type === "free" ? "Free" : "Paid"}
+          />
         </div>
 
-        <div style={{ marginTop: 16, display: "flex", gap: 12, alignItems: "center" }}>
-          {/* Save button (your reusable component) */}
-          <SaveButton eventId={event.id} onChange={() => { /* optional */ }} />
-          <button className="btn btn-ghost" onClick={() => downloadIcs(event)}>Add to Calendar</button>
+        <div
+          style={{
+            marginTop: 16,
+            display: "flex",
+            gap: 12,
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <SaveButton eventId={event.id} onChange={() => {}} />
 
-          {/* Claim button (students only) */}
+          <button
+            className="btn btn-ghost"
+            type="button"
+            onClick={() => downloadIcs(event)}
+          >
+            Add to Calendar
+          </button>
+
           {isStudent && (
             <ClaimTicketButton
-              isEligible={true}
+              isEligible
               hasClaimed={hasClaimed}
               soldOut={soldOut}
               loading={claimLoading}
@@ -212,7 +275,6 @@ async function handleClaim() {
             />
           )}
 
-          {/* Status message */}
           {(soldOut || hasClaimed) && (
             <span style={{ color: "#bbb" }}>
               {soldOut ? "❌ Sold out" : "🎟️ Ticket claimed"}
@@ -221,7 +283,17 @@ async function handleClaim() {
         </div>
       </section>
 
-      {/* Confirmation modal */}
+      {/* Organizer-only Waitlist tab (Task-ORG-06-FE-01) */}
+      {isOrganizer && (
+        <section style={{ marginTop: 24 }}>
+          <h2 style={{ fontSize: 18, marginBottom: 8 }}>Waitlist Management</h2>
+          <EventWaitlistTab
+            eventId={event.id.toString()}
+            isOwner={true} // TODO: replace with real "is this user the event owner?" check
+          />
+        </section>
+      )}
+
       <TicketConfirmationModal
         open={!!ticket}
         data={ticket}
@@ -245,9 +317,4 @@ function Info({ label, value }: { label: string; value: string }) {
       <div style={{ fontWeight: 600 }}>{value}</div>
     </div>
   );
-
-  
-  
-
-
 }

--- a/src/client/src/pages/EventWaitlistTab.tsx
+++ b/src/client/src/pages/EventWaitlistTab.tsx
@@ -1,0 +1,157 @@
+// src/pages/organizer/EventWaitlistTab.tsx
+import  {
+    useCallback,
+    useEffect,
+    useState,
+    type FC,
+  } from "react";
+  import WaitlistTable from "../components/WaitlistTable";
+  import type { WaitlistEntry } from "../lib/waitlist.api";
+  import {
+    fetchWaitlist,
+    promoteFromWaitlist,
+    removeFromWaitlist,
+  } from "../lib/waitlist.api";
+  
+  // If you have an auth context, replace this with a real hook.
+  function useAuthToken() {
+    // Example only – adapt to your app:
+    const token = window.localStorage.getItem("token") || undefined;
+    return { token };
+  }
+  
+  interface EventWaitlistTabProps {
+    eventId: string;
+    isOwner: boolean; // parent should pass this based on current user vs event.ownerId
+  }
+  
+  const EventWaitlistTab: FC<EventWaitlistTabProps> = ({ eventId, isOwner }) => {
+    const { token } = useAuthToken();
+  
+    const [items, setItems] = useState<WaitlistEntry[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+  
+    const loadWaitlist = useCallback(
+      async (opts?: { silent?: boolean }) => {
+        try {
+          if (!opts?.silent) {
+            setLoading(true);
+          } else {
+            setRefreshing(true);
+          }
+          setError(null);
+          const data = await fetchWaitlist(eventId, token);
+          setItems(data);
+        } catch (err) {
+          console.error("Failed to load waitlist", err);
+          setError("Failed to load waitlist. Please try again.");
+        } finally {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      },
+      [eventId, token]
+    );
+  
+    useEffect(() => {
+      void loadWaitlist();
+    }, [loadWaitlist]);
+  
+    const handlePromote = useCallback(
+      async (entry: WaitlistEntry) => {
+        const ok = window.confirm(
+          `Promote ${entry.attendeeName} from waitlist to attendee?`
+        );
+        if (!ok) return;
+  
+        try {
+          setLoading(true);
+          await promoteFromWaitlist(eventId, entry.id, token);
+          // Option 1: refetch from backend so we stay in sync
+          await loadWaitlist({ silent: true });
+        } catch (err) {
+          console.error("Failed to promote from waitlist", err);
+          window.alert("Failed to promote attendee. Please try again.");
+        } finally {
+          setLoading(false);
+        }
+      },
+      [eventId, token, loadWaitlist]
+    );
+  
+    const handleRemove = useCallback(
+      async (entry: WaitlistEntry) => {
+        const ok = window.confirm(
+          `Remove ${entry.attendeeName} from the waitlist?`
+        );
+        if (!ok) return;
+  
+        try {
+          setLoading(true);
+          await removeFromWaitlist(eventId, entry.id, token);
+          await loadWaitlist({ silent: true });
+        } catch (err) {
+          console.error("Failed to remove from waitlist", err);
+          window.alert("Failed to remove attendee. Please try again.");
+        } finally {
+          setLoading(false);
+        }
+      },
+      [eventId, token, loadWaitlist]
+    );
+  
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h2 className="text-base font-semibold">Waitlist</h2>
+            <p className="text-xs text-slate-500">
+              View and manage attendees waiting for this event.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {refreshing && (
+              <span className="text-xs text-slate-400">
+                Syncing with server...
+              </span>
+            )}
+            <button
+              type="button"
+              className="rounded-md border px-3 py-1 text-xs font-medium"
+              disabled={loading}
+              onClick={() => {
+                void loadWaitlist({ silent: true });
+              }}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+  
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+            {error}
+          </div>
+        )}
+  
+        {loading && !items.length ? (
+          <div className="rounded-md border px-4 py-3 text-sm text-slate-500">
+            Loading waitlist...
+          </div>
+        ) : (
+          <WaitlistTable
+            items={items}
+            loading={loading}
+            canManage={isOwner}
+            onPromote={handlePromote}
+            onRemove={handleRemove}
+          />
+        )}
+      </div>
+    );
+  };
+  
+  export default EventWaitlistTab;
+  


### PR DESCRIPTION
This PR adds the complete frontend implementation for the Organizer Waitlist Management feature. Organizers can now view and manage the waitlist for their event directly from the event detail page. The new tab includes a table view, real-time updates, and actionable controls (promote/remove) with confirmation prompts.