### PR TITLE
Complete : Task-ADM-05-BE-01 Implement Policy & Audit Endpoints

### DIFF
--- a/src/server/db/migrations/create_waitlist_policy_and_audit.sql
+++ b/src/server/db/migrations/create_waitlist_policy_and_audit.sql
@@ -1,0 +1,17 @@
+-- server/db/migrations/20251123_create_waitlist_policy_and_audit.sql
+
+CREATE TABLE IF NOT EXISTS waitlist_policy (
+  id SERIAL PRIMARY KEY,
+  max_size INTEGER,
+  auto_promote BOOLEAN NOT NULL DEFAULT false,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS waitlist_policy_audit (
+  id SERIAL PRIMARY KEY,
+  admin_id INTEGER NOT NULL,
+  changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  old_value JSONB,
+  new_value JSONB
+);

--- a/src/server/routes/admin.waitlist.routes.js
+++ b/src/server/routes/admin.waitlist.routes.js
@@ -1,0 +1,116 @@
+// server/routes/admin.waitlist.routes.js
+const express = require("express");
+const router = express.Router();
+
+const {
+  authenticateToken,
+  requireAdmin,
+} = require("../middleware/auth");
+
+const {
+  getGlobalWaitlistPolicy,
+  upsertGlobalWaitlistPolicy,
+  queryWaitlistAudit,
+} = require("../waitlistPolicy.repo");
+
+// All routes in this file: admin-only
+router.use(authenticateToken, requireAdmin);
+
+/**
+ * POST /admin/waitlist/policy
+ * Body: { maxSize?: number | null, autoPromote: boolean, enabled: boolean }
+ * Effect: updates global waitlist policy and writes audit record.
+ */
+router.post("/policy", async (req, res) => {
+  try {
+    const { maxSize, autoPromote, enabled } = req.body || {};
+
+    if (typeof autoPromote !== "boolean" || typeof enabled !== "boolean") {
+      return res.status(400).json({
+        code: "BAD_REQUEST",
+        message: "autoPromote and enabled are required boolean fields.",
+      });
+    }
+
+    let parsedMax = null;
+    if (maxSize !== undefined && maxSize !== null && maxSize !== "") {
+      const n = Number(maxSize);
+      if (!Number.isFinite(n) || n <= 0) {
+        return res.status(400).json({
+          code: "BAD_REQUEST",
+          message: "maxSize must be a positive number or null.",
+        });
+      }
+      parsedMax = n;
+    }
+
+    const adminId = req.user?.id || null;
+
+    const newPolicy = await upsertGlobalWaitlistPolicy(
+      {
+        maxSize: parsedMax,
+        autoPromote,
+        enabled,
+      },
+      adminId
+    );
+
+    return res.status(200).json({
+      message: "Waitlist policy updated successfully.",
+      policy: newPolicy,
+    });
+  } catch (err) {
+    console.error("Error updating waitlist policy", err);
+    return res
+      .status(500)
+      .json({ code: "INTERNAL", message: "Failed to update waitlist policy." });
+  }
+});
+
+/**
+ * GET /admin/waitlist/policy
+ * Optional helper to fetch current policy (for admin UI).
+ */
+router.get("/policy", async (_req, res) => {
+  try {
+    const policy = await getGlobalWaitlistPolicy();
+    return res.status(200).json({ policy });
+  } catch (err) {
+    console.error("Error fetching waitlist policy", err);
+    return res
+      .status(500)
+      .json({ code: "INTERNAL", message: "Failed to fetch waitlist policy." });
+  }
+});
+
+/**
+ * GET /admin/waitlist/audit
+ * Query params:
+ *   adminId?: number
+ *   from?: ISO date
+ *   to?: ISO date
+ *   page?: number
+ *   pageSize?: number
+ */
+router.get("/audit", async (req, res) => {
+  try {
+    const { adminId, from, to, page, pageSize } = req.query;
+
+    const result = await queryWaitlistAudit({
+      adminId: adminId ? Number(adminId) : undefined,
+      from: from || undefined,
+      to: to || undefined,
+      page: page ? Number(page) : undefined,
+      pageSize: pageSize ? Number(pageSize) : undefined,
+    });
+
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error("Error querying waitlist audit", err);
+    return res
+      .status(500)
+      .json({ code: "INTERNAL", message: "Failed to fetch waitlist audit." });
+  }
+});
+
+module.exports = router;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -23,6 +23,7 @@ const adminOrgsRouter = require("./routes/admin.orgs.routes");
 const adminAnalyticsRouter = require("./routes/admin.analytics.routes");
 
 const waitlistRoutes = require("./routes/events.waitlist.routes");
+const adminWaitlistRoutes = require("./routes/admin.waitlist.routes");
 
 
 const app = express();
@@ -64,6 +65,8 @@ app.use("/api/org/events", orgEventsRouter);
 app.use("/", adminOrgsRouter);
 app.use("/", adminAnalyticsRouter);
 app.use("/admin", adminRouter);
+app.use("/admin/waitlist", adminWaitlistRoutes);
+
 
 // offers
 app.use("/offers", offersRoutes);

--- a/src/server/waitlistPolicy.repo.js
+++ b/src/server/waitlistPolicy.repo.js
@@ -1,0 +1,184 @@
+// server/waitlistPolicy.repo.js
+const pool = require("./db");
+
+/**
+ * Get the most recent global waitlist policy.
+ * Returns null if none exists yet.
+ */
+async function getGlobalWaitlistPolicy() {
+  const result = await pool.query(
+    `
+    SELECT id,
+           max_size,
+           auto_promote,
+           enabled,
+           updated_at
+    FROM waitlist_policy
+    ORDER BY updated_at DESC
+    LIMIT 1
+    `
+  );
+
+  if (result.rows.length === 0) return null;
+
+  const row = result.rows[0];
+  return {
+    id: row.id,
+    maxSize: row.max_size,
+    autoPromote: row.auto_promote,
+    enabled: row.enabled,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Insert a new global policy and write an audit record.
+ * Returns the new policy object.
+ *
+ * payload: { maxSize, autoPromote, enabled }
+ */
+async function upsertGlobalWaitlistPolicy(payload, adminId) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const previous = await client.query(
+      `
+      SELECT max_size, auto_promote, enabled, updated_at
+      FROM waitlist_policy
+      ORDER BY updated_at DESC
+      LIMIT 1
+      `
+    );
+
+    const oldValue =
+      previous.rows.length > 0
+        ? {
+            maxSize: previous.rows[0].max_size,
+            autoPromote: previous.rows[0].auto_promote,
+            enabled: previous.rows[0].enabled,
+            updatedAt: previous.rows[0].updated_at,
+          }
+        : null;
+
+    const insertPolicy = await client.query(
+      `
+      INSERT INTO waitlist_policy (max_size, auto_promote, enabled)
+      VALUES ($1, $2, $3)
+      RETURNING id, max_size, auto_promote, enabled, updated_at
+      `,
+      [payload.maxSize ?? null, payload.autoPromote, payload.enabled]
+    );
+
+    const newRow = insertPolicy.rows[0];
+    const newValue = {
+      maxSize: newRow.max_size,
+      autoPromote: newRow.auto_promote,
+      enabled: newRow.enabled,
+      updatedAt: newRow.updated_at,
+    };
+
+    await client.query(
+      `
+      INSERT INTO waitlist_policy_audit
+        (admin_id, old_value, new_value)
+      VALUES ($1, $2::jsonb, $3::jsonb)
+      `,
+      [adminId, JSON.stringify(oldValue), JSON.stringify(newValue)]
+    );
+
+    await client.query("COMMIT");
+
+    return {
+      id: newRow.id,
+      maxSize: newRow.max_size,
+      autoPromote: newRow.auto_promote,
+      enabled: newRow.enabled,
+      updatedAt: newRow.updated_at,
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Query audit history with filters + pagination.
+ * params: { adminId?, from?, to?, page?, pageSize? }
+ */
+async function queryWaitlistAudit(params = {}) {
+  const {
+    adminId,
+    from,
+    to,
+    page = 1,
+    pageSize = 20,
+  } = params;
+
+  const limit = Math.max(1, Math.min(100, Number(pageSize) || 20));
+  const offset = (Math.max(1, Number(page) || 1) - 1) * limit;
+
+  const conditions = [];
+  const values = [];
+  let idx = 1;
+
+  if (adminId) {
+    conditions.push(`admin_id = $${idx++}`);
+    values.push(adminId);
+  }
+
+  if (from) {
+    conditions.push(`changed_at >= $${idx++}`);
+    values.push(from);
+  }
+
+  if (to) {
+    conditions.push(`changed_at <= $${idx++}`);
+    values.push(to);
+  }
+
+  const whereClause =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const query = `
+    SELECT
+      id,
+      admin_id,
+      changed_at,
+      old_value,
+      new_value,
+      COUNT(*) OVER() AS total_count
+    FROM waitlist_policy_audit
+    ${whereClause}
+    ORDER BY changed_at DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+  `;
+
+  const result = await pool.query(query, values);
+
+  const rows = result.rows.map((row) => ({
+    id: row.id,
+    adminId: row.admin_id,
+    changedAt: row.changed_at,
+    oldValue: row.old_value,
+    newValue: row.new_value,
+  }));
+
+  const total = result.rows.length > 0 ? Number(result.rows[0].total_count) : 0;
+
+  return {
+    items: rows,
+    page: Number(page),
+    pageSize: limit,
+    total,
+  };
+}
+
+module.exports = {
+  getGlobalWaitlistPolicy,
+  upsertGlobalWaitlistPolicy,
+  queryWaitlistAudit,
+};


### PR DESCRIPTION
Implements admin-only backend support for managing the global waitlist policy and viewing audit history.

What was added
- Added waitlistPolicy.repo.js with:
  - getGlobalWaitlistPolicy()
  - upsertGlobalWaitlistPolicy()
  - queryWaitlistAudit()
- Added admin.waitlist.routes.js with:
  - POST /admin/waitlist/policy
  - GET /admin/waitlist/policy
  - GET /admin/waitlist/audit
- Added DB migration to create:
  - waitlist_policy
  - waitlist_policy_audit

