### PR TITLE
Complete: Task-ADM-05-FE-01: Build Admin Policy & Audit UI 

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -18,6 +18,7 @@ import MyTickets from "./MyTickets";
 import SavedEvents from "./pages/SavedEvents";
 import Scan from "./pages/Scan";
 import AdminHome from "./pages/admin/AdminHome";
+import WaitlistPolicyPage from "./pages/WaitlistPolicyPage";
 
 // Components
 import Header from "./components/Header";
@@ -144,6 +145,14 @@ export default function App() {
             element={
               <RoleRoute roles={["admin"]}>
                 <OrganizationsPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="/admin/waitlist-policy"
+            element={
+              <RoleRoute roles={["admin"]}>
+                <WaitlistPolicyPage />
               </RoleRoute>
             }
           />

--- a/src/client/src/components/WaitlistAuditTable.tsx
+++ b/src/client/src/components/WaitlistAuditTable.tsx
@@ -1,0 +1,226 @@
+// src/components/admin/WaitlistAuditTable.tsx
+import React from "react";
+import type {
+  WaitlistAuditItem,
+  AuditFilters,
+} from "../lib/adminWaitlistPolicy.api";
+
+interface WaitlistAuditTableProps {
+  items: WaitlistAuditItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+  loading?: boolean;
+  filters: AuditFilters;
+  onFiltersChange: (next: AuditFilters) => void;
+  onPageChange: (page: number) => void;
+  // for link navigation
+  buildEventLink?: (eventId: number) => string;
+  buildUserLink?: (userId: number) => string;
+}
+
+const WaitlistAuditTable: React.FC<WaitlistAuditTableProps> = ({
+  items,
+  page,
+  pageSize,
+  total,
+  loading = false,
+  filters,
+  onFiltersChange,
+  onPageChange,
+  buildEventLink,
+  buildUserLink,
+}) => {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const handleFilterChange = (
+    key: keyof AuditFilters,
+    value: string | undefined
+  ) => {
+    onFiltersChange({
+      ...filters,
+      [key]: value || undefined,
+      page: 1,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-3 rounded-lg border border-slate-700 bg-[#121212] p-3 text-xs">
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">Event ID</label>
+          <input
+            type="text"
+            value={filters.eventId ?? ""}
+            onChange={(e) => handleFilterChange("eventId", e.target.value)}
+            className="w-32 rounded border border-slate-600 bg-black px-2 py-1 text-xs"
+            placeholder="e.g. 42"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">Org ID</label>
+          <input
+            type="text"
+            value={filters.orgId ?? ""}
+            onChange={(e) => handleFilterChange("orgId", e.target.value)}
+            className="w-32 rounded border border-slate-600 bg-black px-2 py-1 text-xs"
+            placeholder="e.g. 7"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">User ID</label>
+          <input
+            type="text"
+            value={filters.userId ?? ""}
+            onChange={(e) => handleFilterChange("userId", e.target.value)}
+            className="w-32 rounded border border-slate-600 bg-black px-2 py-1 text-xs"
+            placeholder="e.g. 15"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">From date</label>
+          <input
+            type="date"
+            value={filters.from ?? ""}
+            onChange={(e) => handleFilterChange("from", e.target.value)}
+            className="rounded border border-slate-600 bg-black px-2 py-1 text-xs"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">To date</label>
+          <input
+            type="date"
+            value={filters.to ?? ""}
+            onChange={(e) => handleFilterChange("to", e.target.value)}
+            className="rounded border border-slate-600 bg-black px-2 py-1 text-xs"
+          />
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-700 bg-[#101010]">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-900/60 text-[11px] uppercase tracking-wide text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">Changed At</th>
+              <th className="px-3 py-2 text-left">Admin</th>
+              <th className="px-3 py-2 text-left">Old Policy</th>
+              <th className="px-3 py-2 text-left">New Policy</th>
+              <th className="px-3 py-2 text-left">Links</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && !loading && (
+              <tr>
+                <td
+                  className="px-3 py-4 text-center text-slate-500"
+                  colSpan={5}
+                >
+                  No audit entries found for these filters.
+                </td>
+              </tr>
+            )}
+
+            {items.map((row) => {
+              const oldValue = row.oldValue || {};
+              const newValue = row.newValue || {};
+
+              return (
+                <tr
+                  key={row.id}
+                  className="border-t border-slate-800 hover:bg-slate-900/60"
+                >
+                  <td className="px-3 py-2 align-top">
+                    {new Date(row.changedAt).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {row.adminId ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <code className="whitespace-pre-wrap text-[11px] text-slate-300">
+                      {JSON.stringify(oldValue, null, 2)}
+                    </code>
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <code className="whitespace-pre-wrap text-[11px] text-sky-300">
+                      {JSON.stringify(newValue, null, 2)}
+                    </code>
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <div className="flex flex-col gap-1">
+                      {row.eventId && buildEventLink ? (
+                        <a
+                          href={buildEventLink(row.eventId)}
+                          className="text-[11px] text-sky-400 hover:underline"
+                        >
+                          View event #{row.eventId}
+                        </a>
+                      ) : (
+                        <span className="text-[11px] text-slate-500">
+                          No event link
+                        </span>
+                      )}
+
+                      {row.userId && buildUserLink ? (
+                        <a
+                          href={buildUserLink(row.userId)}
+                          className="text-[11px] text-sky-400 hover:underline"
+                        >
+                          View user #{row.userId}
+                        </a>
+                      ) : (
+                        <span className="text-[11px] text-slate-500">
+                          No user link
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+
+            {loading && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-3 py-4 text-center text-slate-400"
+                >
+                  Loading audit entries…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-slate-400">
+        <span>
+          Page {page} of {totalPages} ({total} entries)
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={page <= 1 || loading}
+            onClick={() => onPageChange(page - 1)}
+            className="rounded-md border border-slate-600 px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            disabled={page >= totalPages || loading}
+            onClick={() => onPageChange(page + 1)}
+            className="rounded-md border border-slate-600 px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WaitlistAuditTable;

--- a/src/client/src/components/WaitlistPolicyForm.tsx
+++ b/src/client/src/components/WaitlistPolicyForm.tsx
@@ -1,0 +1,144 @@
+// src/components/admin/WaitlistPolicyForm.tsx
+import React, { useState, type FormEvent } from "react";
+import type { WaitlistPolicy } from "../lib/adminWaitlistPolicy.api";
+
+interface WaitlistPolicyFormProps {
+  initialPolicy: WaitlistPolicy | null;
+  onSubmit: (data: {
+    maxSize: number | null;
+    autoPromote: boolean;
+    enabled: boolean;
+  }) => Promise<void> | void;
+  submitting?: boolean;
+}
+
+const WaitlistPolicyForm: React.FC<WaitlistPolicyFormProps> = ({
+  initialPolicy,
+  onSubmit,
+  submitting = false,
+}) => {
+  const [maxSizeInput, setMaxSizeInput] = useState<string>(
+    initialPolicy?.maxSize != null ? String(initialPolicy.maxSize) : ""
+  );
+  const [autoPromote, setAutoPromote] = useState<boolean>(
+    initialPolicy?.autoPromote ?? false
+  );
+  const [enabled, setEnabled] = useState<boolean>(
+    initialPolicy?.enabled ?? true
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    let maxSize: number | null = null;
+    if (maxSizeInput.trim() !== "") {
+      const parsed = Number(maxSizeInput);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        setError("Max waitlist size must be a positive number or left blank.");
+        return;
+      }
+      maxSize = parsed;
+    }
+
+    try {
+      await onSubmit({
+        maxSize,
+        autoPromote,
+        enabled,
+      });
+      setSuccess("Waitlist policy updated successfully.");
+    } catch (err) {
+      console.error("Failed to update policy", err);
+      setError("Failed to update waitlist policy. Please try again.");
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-lg border border-slate-700 bg-[#121212] p-4"
+    >
+      <h2 className="text-lg font-semibold">Waitlist Policy</h2>
+      <p className="text-xs text-slate-400">
+        Configure global defaults for how event waitlists behave across the
+        platform.
+      </p>
+
+      {error && (
+        <div className="rounded-md border border-red-500 bg-red-950 px-3 py-2 text-xs text-red-200">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="rounded-md border border-emerald-500 bg-emerald-950 px-3 py-2 text-xs text-emerald-200">
+          {success}
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">
+          Max waitlist size (blank = unlimited)
+        </label>
+        <input
+          type="number"
+          min={1}
+          inputMode="numeric"
+          value={maxSizeInput}
+          onChange={(e) => setMaxSizeInput(e.target.value)}
+          className="w-full rounded-md border border-slate-600 bg-black px-3 py-2 text-sm outline-none focus:border-sky-500"
+          placeholder="e.g. 100"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="autoPromote"
+          type="checkbox"
+          checked={autoPromote}
+          onChange={(e) => setAutoPromote(e.target.checked)}
+          className="h-4 w-4 rounded border-slate-600 bg-black"
+        />
+        <label htmlFor="autoPromote" className="text-sm">
+          Automatically promote attendees from waitlist when seats open
+        </label>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="enabled"
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          className="h-4 w-4 rounded border-slate-600 bg-black"
+        />
+        <label htmlFor="enabled" className="text-sm">
+          Waitlist enabled globally
+        </label>
+      </div>
+
+      {initialPolicy?.updatedAt && (
+        <p className="text-[11px] text-slate-500">
+          Last updated:{" "}
+          {new Date(initialPolicy.updatedAt).toLocaleString() || "—"}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-md border border-sky-500 px-4 py-2 text-sm font-medium text-sky-100 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? "Saving..." : "Save Policy"}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default WaitlistPolicyForm;

--- a/src/client/src/lib/adminWaitlistPolicy.api.ts
+++ b/src/client/src/lib/adminWaitlistPolicy.api.ts
@@ -1,0 +1,114 @@
+// src/lib/adminWaitlistPolicy.api.ts
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:4000";
+
+export interface WaitlistPolicy {
+  id?: number;
+  maxSize: number | null;
+  autoPromote: boolean;
+  enabled: boolean;
+  updatedAt?: string;
+}
+
+export interface WaitlistAuditItem {
+  id: number;
+  adminId: number | null;
+  changedAt: string;
+  oldValue: any;
+  newValue: any;
+  // optional – if backend ever adds them, UI will pick them up
+  eventId?: number | null;
+  orgId?: number | null;
+  userId?: number | null;
+}
+
+export interface WaitlistAuditResponse {
+  items: WaitlistAuditItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+function getAuthHeaders() {
+  const token = window.localStorage.getItem("token");
+  if (!token) return {};
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function fetchWaitlistPolicy(): Promise<WaitlistPolicy | null> {
+  const res = await axios.get<{ policy: WaitlistPolicy | null }>(
+    `${BASE_URL}/admin/waitlist/policy`,
+    {
+      headers: {
+        ...getAuthHeaders(),
+      },
+    }
+  );
+  return res.data.policy;
+}
+
+export async function updateWaitlistPolicy(input: {
+  maxSize: number | null;
+  autoPromote: boolean;
+  enabled: boolean;
+}): Promise<WaitlistPolicy> {
+  const res = await axios.post<{ policy: WaitlistPolicy }>(
+    `${BASE_URL}/admin/waitlist/policy`,
+    {
+      maxSize: input.maxSize,
+      autoPromote: input.autoPromote,
+      enabled: input.enabled,
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        ...getAuthHeaders(),
+      },
+    }
+  );
+  return res.data.policy;
+}
+
+export interface AuditFilters {
+  eventId?: string;
+  orgId?: string;
+  userId?: string;
+  from?: string;
+  to?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+/**
+ * Fetch audit history with filtering + pagination.
+ * NOTE: backend currently supports adminId/from/to/page/pageSize.
+ * We still send event/org/user so the API is future-proof.
+ */
+export async function fetchWaitlistAudit(
+  filters: AuditFilters
+): Promise<WaitlistAuditResponse> {
+  const params: Record<string, string | number> = {};
+
+  if (filters.eventId) params.eventId = filters.eventId;
+  if (filters.orgId) params.orgId = filters.orgId;
+  if (filters.userId) params.userId = filters.userId;
+  if (filters.from) params.from = filters.from;
+  if (filters.to) params.to = filters.to;
+  if (filters.page) params.page = filters.page;
+  if (filters.pageSize) params.pageSize = filters.pageSize;
+
+  const res = await axios.get<WaitlistAuditResponse>(
+    `${BASE_URL}/admin/waitlist/audit`,
+    {
+      headers: {
+        ...getAuthHeaders(),
+      },
+      params,
+    }
+  );
+
+  return res.data;
+}

--- a/src/client/src/pages/WaitlistPolicyPage.tsx
+++ b/src/client/src/pages/WaitlistPolicyPage.tsx
@@ -1,0 +1,163 @@
+// src/pages/admin/WaitlistPolicyPage.tsx
+import React, { useEffect, useState, useCallback } from "react";
+import WaitlistPolicyForm from "../components/WaitlistPolicyForm";
+import WaitlistAuditTable from "../components/WaitlistAuditTable";
+import {
+  fetchWaitlistPolicy,
+  updateWaitlistPolicy,
+  fetchWaitlistAudit,
+  type WaitlistPolicy,
+  type WaitlistAuditResponse,
+  type AuditFilters,
+} from "../lib/adminWaitlistPolicy.api";
+
+// TODO: hook this into your real auth context
+type Role = "student" | "organizer" | "admin";
+
+const WaitlistPolicyPage: React.FC = () => {
+  const userRole: Role = "admin"; // replace with actual role from your auth
+  const isAdmin = userRole === "admin";
+
+  const [policy, setPolicy] = useState<WaitlistPolicy | null>(null);
+  const [policyLoading, setPolicyLoading] = useState<boolean>(false);
+  const [policySubmitting, setPolicySubmitting] = useState<boolean>(false);
+
+  const [audit, setAudit] = useState<WaitlistAuditResponse | null>(null);
+  const [auditLoading, setAuditLoading] = useState<boolean>(false);
+
+  const [filters, setFilters] = useState<AuditFilters>({
+    page: 1,
+    pageSize: 10,
+  });
+
+  const loadPolicy = useCallback(async () => {
+    setPolicyLoading(true);
+    try {
+      const p = await fetchWaitlistPolicy();
+      setPolicy(p);
+    } catch (err) {
+      console.error("Failed to fetch waitlist policy", err);
+    } finally {
+      setPolicyLoading(false);
+    }
+  }, []);
+
+  const loadAudit = useCallback(
+    async (opts?: { page?: number }) => {
+      setAuditLoading(true);
+      try {
+        const resp = await fetchWaitlistAudit({
+          ...filters,
+          page: opts?.page ?? filters.page ?? 1,
+          pageSize: filters.pageSize ?? 10,
+        });
+        setAudit(resp);
+        setFilters((prev) => ({
+          ...prev,
+          page: resp.page,
+          pageSize: resp.pageSize,
+        }));
+      } catch (err) {
+        console.error("Failed to fetch waitlist audit", err);
+      } finally {
+        setAuditLoading(false);
+      }
+    },
+    [filters]
+  );
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    void loadPolicy();
+  }, [isAdmin, loadPolicy]);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    void loadAudit();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin, filters.from, filters.to, filters.eventId, filters.orgId, filters.userId]);
+
+  const handlePolicySubmit = async (data: {
+    maxSize: number | null;
+    autoPromote: boolean;
+    enabled: boolean;
+  }) => {
+    setPolicySubmitting(true);
+    try {
+      const updated = await updateWaitlistPolicy(data);
+      setPolicy(updated);
+      // refresh audit so admin sees latest change logged
+      await loadAudit({ page: 1 });
+    } finally {
+      setPolicySubmitting(false);
+    }
+  };
+
+  const handleFiltersChange = (next: AuditFilters) => {
+    setFilters(next);
+  };
+
+  const handlePageChange = (page: number) => {
+    setFilters((prev) => ({ ...prev, page }));
+  };
+
+  const buildEventLink = (eventId: number) => `/events/${eventId}`;
+  const buildUserLink = (userId: number) => `/admin/users/${userId}`;
+
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto max-w-4xl p-4 text-sm text-red-300">
+        <h1 className="mb-2 text-lg font-semibold">Access denied</h1>
+        <p>You must be an admin to view the waitlist policy and audit logs.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-4 p-4">
+      <header className="mb-2">
+        <h1 className="text-2xl font-semibold">Waitlist Policy &amp; Audit</h1>
+        <p className="text-sm text-slate-400">
+          Manage global waitlist defaults and review audit history for policy
+          changes.
+        </p>
+      </header>
+
+      {policyLoading ? (
+        <div className="rounded-lg border border-slate-700 bg-[#121212] p-4 text-sm text-slate-400">
+          Loading current policy…
+        </div>
+      ) : (
+        <WaitlistPolicyForm
+          initialPolicy={policy}
+          onSubmit={handlePolicySubmit}
+          submitting={policySubmitting}
+        />
+      )}
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">Audit</h2>
+          <span className="text-[11px] text-slate-500">
+            Showing changes to the global waitlist policy.
+          </span>
+        </div>
+
+        <WaitlistAuditTable
+          items={audit?.items ?? []}
+          page={audit?.page ?? filters.page ?? 1}
+          pageSize={audit?.pageSize ?? filters.pageSize ?? 10}
+          total={audit?.total ?? 0}
+          loading={auditLoading}
+          filters={filters}
+          onFiltersChange={handleFiltersChange}
+          onPageChange={handlePageChange}
+          buildEventLink={buildEventLink}
+          buildUserLink={buildUserLink}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default WaitlistPolicyPage;


### PR DESCRIPTION
### Features Added

### 1. Waitlist Policy Form
- Fetches current global policy using `GET /admin/waitlist/policy`
- Allows admins to update:
  - Max waitlist size
  - Auto-promote behavior
  - Global waitlist enabled flag
- Submits updates through `POST /admin/waitlist/policy`
- Displays success/error feedback
- Automatically refreshes audit logs after a successful update

### 2. Audit History Table
- Loads audit entries via `GET /admin/waitlist/audit`
- Supports pagination and filtering:
  - Event ID
  - Organization ID
  - User ID
  - Date range (from/to)
- Displays old vs. new policy values
- Provides links to event/user pages when available

### 3. Access Control
- Page is wrapped with `<RoleRoute roles={["admin"]}>`
- Non-admins are blocked in the UI and the backend returns 403 as expected
